### PR TITLE
[mod]ポップアップエディターでドラッグ・アンド・ドロップするとグラフ移動するバグを修正

### DIFF
--- a/src/components/organisms/Editor.vue
+++ b/src/components/organisms/Editor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="Editor">
+  <div class="Editor" @touchmove.stop @pointermove.stop>
     <div id="toolbar">
       <button class="custom-button" @click="isRelationOpen = !isRelationOpen" v-tooltip="'関連リンク'">
         <Icon icon="list-ul" :class="{iconOn:isRelationOpen}" :size="14" :font="18" />


### PR DESCRIPTION
## 概要
ポップアップエディターでドラッグ・アンド・ドロップするとグラフ移動するバグを修正
どちらから制限するか迷ったけど、エディター側から伝搬防ぐのが簡単そうやったのでそちらで対応

## 補足
こういったイベント管理は、どちらがわから制御するのがいいのだろうか？
受ける側でself、伝える側でstop
統一した方がいいのか？難しいので別に良いのか？
難しい笑